### PR TITLE
added fix for esgf logon failure

### DIFF
--- a/phoenix/esgf/logon.py
+++ b/phoenix/esgf/logon.py
@@ -61,6 +61,11 @@ def logon(username=None, password=None, hostname=None, interactive=False, outdir
     # TODO: fix encoding
     if six.PY2:
         hostname = hostname.encode('utf-8', 'ignore')
+    # TODO: disable this fix when integrated in myproxyclient
+    from myproxy.client import MyProxyClient
+    from OpenSSL import SSL
+    MyProxyClient.SSL_METHOD = SSL.TLSv1_2_METHOD
+    # logon
     lm.logon(username=username, password=password, hostname=hostname,
              bootstrap=True, update_trustroots=False, interactive=interactive)
     return os.path.join(outdir, ESGF_CREDENTIALS)


### PR DESCRIPTION
This PR fixes the ESGF logon failure. It sets the SSL method:
```
MyProxyClient.SSL_METHOD = SSL.TLSv1_2_METHOD
``` 