### PR TITLE
use myproxyclient=2.0.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - pytz
   - owslib=0.17
   - transaction
-  - myproxyclient=2.0
+  #- myproxyclient=2.0
   - genshi=0.7
 # celery
   - celery=3.1
@@ -72,4 +72,5 @@ dependencies:
       - WebHelpers2
       - WebHelpers2_grid
       - repoze.sendmail
+      - myproxyclient==2.0.3
       - esgf-pyclient==0.2.1

--- a/phoenix/esgf/logon.py
+++ b/phoenix/esgf/logon.py
@@ -61,10 +61,6 @@ def logon(username=None, password=None, hostname=None, interactive=False, outdir
     # TODO: fix encoding
     if six.PY2:
         hostname = hostname.encode('utf-8', 'ignore')
-    # TODO: disable this fix when integrated in myproxyclient
-    from myproxy.client import MyProxyClient
-    from OpenSSL import SSL
-    MyProxyClient.SSL_METHOD = SSL.TLSv1_2_METHOD
     # logon
     lm.logon(username=username, password=password, hostname=hostname,
              bootstrap=True, update_trustroots=False, interactive=interactive)


### PR DESCRIPTION
Changes:

* Install latest `myproxyclient=2.0.3` via pip.
* Removed workaround for previous `myproxyclient`.