### PR TITLE
Cleanup buildout cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ OS_NAME := $(shell uname -s 2>/dev/null || echo "unknown")
 CPU_ARCH := $(shell uname -m 2>/dev/null || uname -p 2>/dev/null || echo "unknown")
 
 # Python
-SETUPTOOLS_VERSION := 36.5.0
+SETUPTOOLS_VERSION := 41
 CONDA_VERSION := 4.5
-BUILDOUT_VERSION := 2.12.1
+BUILDOUT_VERSION := 2.13.1
 
 # Anaconda
 ANACONDA_HOME ?= $(HOME)/anaconda

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python=2.7
-  - setuptools=27.2.0
+  - setuptools
   - curl
   - pyopenssl
   - cryptography

--- a/phoenix/wps.py
+++ b/phoenix/wps.py
@@ -103,7 +103,7 @@ class WPSSchema(deform.schema.CSRFSchema):
            An ``WPS`` process description that you want a ``Colander`` schema
            to be generated for.
 
-        \*\*kw
+        **kw
            Represents *all* other options able to be passed to a
            :class:`colander.SchemaNode`. Keywords passed will influence the
            resulting mapped schema accordingly (for instance, passing

--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -7,12 +7,6 @@ newest = false
 download-cache = ${buildout:directory}/downloads
 log-level = INFO
 
-# conda
-conda-env = pyramid-phoenix
-conda-offline = false
-conda-channels = defaults birdhouse
-channel-priority = true
-
 ## extensions
 
 # use python site-packages
@@ -23,9 +17,9 @@ parts =
     phoenix
     phoenix_config
     gunicorn
-    supervisor
-    nginx
-    celery
+    #supervisor
+    #nginx
+    #celery
 
 [settings]
 prefix =  ${environment:HOME}/birdhouse

--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -7,6 +7,9 @@ newest = false
 download-cache = ${buildout:directory}/downloads
 log-level = INFO
 
+# conda
+conda-offline = true
+
 ## extensions
 
 # use python site-packages
@@ -17,9 +20,9 @@ parts =
     phoenix
     phoenix_config
     gunicorn
-    #supervisor
-    #nginx
-    #celery
+    supervisor
+    nginx
+    celery
 
 [settings]
 prefix =  ${environment:HOME}/birdhouse

--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -40,7 +40,6 @@ phoenix-debug = false
 phoenix-secret = f4e044d933767d6d0e022d1020508db3
 phoenix-password =
 log-level = WARNING
-supervisor-url = http://localhost:9001
 mongodb-host = localhost
 mongodb-port = 27027
 mongodb-dbname = phoenix_db
@@ -55,9 +54,6 @@ storage-extensions = default+archives+nc
 esgf-search-url = https://esgf-data.dkrz.de/esg-search
 github-client-id =
 github-client-secret =
-esgf-slcs-url = https://172.28.128.4
-esgf-slcs-client-id =
-esgf-slcs-client-secret =
 # twitcher
 twitcher-host = ${:hostname}
 twitcher-port = ${:https-port}

--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -14,7 +14,7 @@ conda-offline = true
 
 # use python site-packages
 # https://pypi.python.org/pypi/buildout.locallib/
-extensions = buildout.locallib
+# extensions = buildout.locallib
 
 parts =
     phoenix

--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -10,12 +10,6 @@ log-level = INFO
 # conda
 conda-offline = true
 
-## extensions
-
-# use python site-packages
-# https://pypi.python.org/pypi/buildout.locallib/
-# extensions = buildout.locallib
-
 parts =
     phoenix
     phoenix_config

--- a/profiles/development.cfg
+++ b/profiles/development.cfg
@@ -1,0 +1,2 @@
+[buildout]
+extends = prod.cfg debug.cfg

--- a/profiles/docker.cfg
+++ b/profiles/docker.cfg
@@ -2,9 +2,6 @@
 extends = base.cfg versions.cfg
 versions = versions
 
-supervisor-host = *
-supervisor-port = 9001
-
 [settings]
 ## deployment options for debian os
 prefix = /opt/birdhouse

--- a/profiles/versions.cfg
+++ b/profiles/versions.cfg
@@ -1,13 +1,9 @@
 [versions]
-Mako = 1.0.7
 birdhousebuilder.recipe.celery = 0.2.0
 birdhousebuilder.recipe.conda = 0.4.0
-birdhousebuilder.recipe.docker = 0.5.3
 birdhousebuilder.recipe.mongodb = 0.4.0
 birdhousebuilder.recipe.nginx = 0.3.7
 birdhousebuilder.recipe.supervisor = 0.4.0
-buildout.locallib = 0.3.1
 collective.recipe.template = 2.1
-pyramid-twitcher = 0.3.8
 zc.recipe.deployment = 1.3.0
 zc.recipe.egg = 2.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ markers =
     slow: mark test to be slow
 
 [flake8]
-ignore=F401,E402
+ignore=F401,E402,W606
 max-line-length=120
 exclude =
     tests,

--- a/templates/phoenix.ini
+++ b/templates/phoenix.ini
@@ -55,11 +55,6 @@ esgfsearch.url = ${parts.settings['esgf-search-url']}
 github.client.id = ${parts.settings['github-client-id']}
 github.client.secret = ${parts.settings['github-client-secret']}
 
-# esgf slcs server (oauth2)
-esgf.slcs.url = ${parts.settings['esgf-slcs-url']}
-esgf.slcs.client.id = ${parts.settings['esgf-slcs-client-id']}
-esgf.slcs.client.secret = ${parts.settings['esgf-slcs-client-secret']}
-
 # twitcher
 twitcher.url = ${parts.settings['twitcher-url']}
 twitcher.ows_proxy_delegate = ${parts.settings['twitcher-delegate']}


### PR DESCRIPTION
This PR cleans up the buildout config and skips the unused `buildout.locallib` recipe. conda packages will not be updated by the birdhouse recipes (`conda-offline=true`).