### PR TITLE
Changed process list so version appears on the side

### DIFF
--- a/phoenix/processes/templates/processes/list.pt
+++ b/phoenix/processes/templates/processes/list.pt
@@ -29,7 +29,7 @@
               <div class="media-body">
                 <div class="pull-right text-muted text-right" style="font-size: 1.0em;">
                   <span>
-                    <i class="fa fa-star"></i> 3
+                    <i class="fa fa-cogs"></i> v${item.version}
                   </span>
                 </div>
                 <h4 class="media-heading">

--- a/phoenix/processes/views/list.py
+++ b/phoenix/processes/views/list.py
@@ -30,7 +30,8 @@ class ProcessList(MyView):
         items = []
         for process in self.wps.processes:
             item = dict(
-                title="{0.title} {0.processVersion}".format(process),
+                title=process.title,
+                version=process.processVersion,
                 description=getattr(process, 'abstract', ''),
                 media=get_process_media(process),
                 url=self.request.route_path('processes_execute',


### PR DESCRIPTION
Small change to the way processes displayed. Instead of having the version number in the name and "3 stars" to the side, the version number will appear to the side with a cog. Example can be seen in issue #204.
Closes #204 