### PR TITLE
add permissions to wps services

### DIFF
--- a/phoenix/catalog.py
+++ b/phoenix/catalog.py
@@ -96,11 +96,12 @@ class MongodbCatalog(Catalog):
         record['identifier'] = uuid.uuid4().hex
         self.collection.save(record)
 
-    def harvest(self, url, service_title=None, public=False):
+    def harvest(self, url, service_title=None, public=False, group=None):
         try:
             # fetch metadata
             record = _fetch_wps_metadata(url, title=service_title)
             record['public'] = public
+            record['group'] = group
             self.insert_record(record)
         except Exception:
             LOGGER.warning("could not harvest metadata")

--- a/phoenix/processes/views/overview.py
+++ b/phoenix/processes/views/overview.py
@@ -17,6 +17,12 @@ class Overview(MyView):
     def wps_services(self):
         items = []
         for service in self.request.catalog.get_services():
+            if self.request.has_permission('view'):
+                if service.group in ['admin', 'user']:
+                    continue
+            elif self.request.has_permission('edit'):
+                if service.group in ['admin']:
+                    continue
             url = self.request.route_path('processes_list', _query=[('wps', service.identifier)])
             items.append(dict(
                 title=service.title, description=service.abstract, public=service.public, url=url))

--- a/phoenix/processes/views/overview.py
+++ b/phoenix/processes/views/overview.py
@@ -17,11 +17,9 @@ class Overview(MyView):
     def wps_services(self):
         items = []
         for service in self.request.catalog.get_services():
-            if self.request.has_permission('view'):
-                if service.group in ['admin', 'user']:
-                    continue
-            elif self.request.has_permission('edit'):
-                if service.group in ['admin']:
+            print(f"group: {service.group}")
+            if service.group in ['admin']:
+                if not self.request.has_permission('edit'):
                     continue
             url = self.request.route_path('processes_list', _query=[('wps', service.identifier)])
             items.append(dict(

--- a/phoenix/processes/views/overview.py
+++ b/phoenix/processes/views/overview.py
@@ -17,8 +17,10 @@ class Overview(MyView):
     def wps_services(self):
         items = []
         for service in self.request.catalog.get_services():
-            print(f"group: {service.group}")
             if service.group in ['admin']:
+                if not self.request.has_permission('admin'):
+                    continue
+            elif service.group in ['admin', 'user']:
                 if not self.request.has_permission('edit'):
                     continue
             url = self.request.route_path('processes_list', _query=[('wps', service.identifier)])

--- a/phoenix/services/templates/services/service_details.pt
+++ b/phoenix/services/templates/services/service_details.pt
@@ -28,6 +28,7 @@
           <p><strong>Rights:</strong> ${service.rights}</p>
           <p><strong>Creator:</strong> ${service.creator}</p>
           <p tal:condition="hasattr(service, 'public')"><strong>Public Access:</strong> ${service.public}</p>
+          <p><strong>Group:</strong> ${service.group}</p>
         </div>
       </div>
 

--- a/phoenix/services/views/registerservice.py
+++ b/phoenix/services/views/registerservice.py
@@ -6,7 +6,7 @@ from deform import ValidationFailure
 
 from phoenix.views import MyView
 from phoenix.security import check_csrf_token
-from phoenix.security import Admin, User, Guest
+# from phoenix.security import Admin, User, Guest
 
 import deform
 import colander
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger("PHOENIX")
 
 
 class Schema(deform.schema.CSRFSchema):
-    groups = ((Admin, 'Admin'), (User, 'User'), (Guest, 'Guest'))
+    groups = (('admin', 'Admin'), ('user', 'User'), ('guest', 'Guest'))
 
     url = colander.SchemaNode(
         colander.String(),

--- a/phoenix/services/views/registerservice.py
+++ b/phoenix/services/views/registerservice.py
@@ -6,6 +6,7 @@ from deform import ValidationFailure
 
 from phoenix.views import MyView
 from phoenix.security import check_csrf_token
+from phoenix.security import Admin, User, Guest
 
 import deform
 import colander
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger("PHOENIX")
 
 
 class Schema(deform.schema.CSRFSchema):
+    groups = ((Admin, 'Admin'), (User, 'User'), (Guest, 'Guest'))
+
     url = colander.SchemaNode(
         colander.String(),
         title='Service URL',
@@ -34,6 +37,12 @@ class Schema(deform.schema.CSRFSchema):
         title="Public access?",
         description="Check this option if your service has no access restrictions.",
         default=False)
+    group = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf([x[0] for x in choices]),
+        widget=deform.widget.RadioChoiceWidget(values=groups, inline=True),
+        title='Group',
+        description='Select Group')
 
 
 @view_defaults(permission='admin', layout='default')

--- a/phoenix/services/views/registerservice.py
+++ b/phoenix/services/views/registerservice.py
@@ -39,7 +39,7 @@ class Schema(deform.schema.CSRFSchema):
         default=False)
     group = colander.SchemaNode(
         colander.String(),
-        validator=colander.OneOf([x[0] for x in choices]),
+        validator=colander.OneOf([x[0] for x in groups]),
         widget=deform.widget.RadioChoiceWidget(values=groups, inline=True),
         title='Group',
         description='Select Group')

--- a/phoenix/services/views/registerservice.py
+++ b/phoenix/services/views/registerservice.py
@@ -40,6 +40,7 @@ class Schema(deform.schema.CSRFSchema):
     group = colander.SchemaNode(
         colander.String(),
         validator=colander.OneOf([x[0] for x in groups]),
+        default='guest',
         widget=deform.widget.RadioChoiceWidget(values=groups, inline=True),
         title='Group',
         description='Select Group')


### PR DESCRIPTION
This PR adds group permissions (admin, user, guest) to the WPS service registration. Users can only see services with the according permissions, e.a. if not logged in you can only see WPS services with group permission "guest".